### PR TITLE
Fix/layout (main) and table products responsiviness

### DIFF
--- a/Front/app/(root)/layout.tsx
+++ b/Front/app/(root)/layout.tsx
@@ -40,7 +40,7 @@ export default function RootLayout({
 				<Header />
 				<div className="flex flex-grow w-full">
 					<SideBar className="hidden lg:block" />
-					<main className="w-full">{children}</main>
+					<main className="w-full lg:w-[80%]">{children}</main>
 				</div>
 			</AuthProvider>
 		</body>

--- a/Front/components/TableProducts/index.tsx
+++ b/Front/components/TableProducts/index.tsx
@@ -63,7 +63,7 @@ const TableProducts = ({ tab }: { tab: "expired" | "aboutToExpire" }) => {
 	}
 
 	return (
-		<div className="max-h-[600px] max-w-[80%] md:w-full overflow-y-auto overflow-x-auto bg-white shadow-lg border-t-[1px] rounded-lg">
+		<div className="max-h-[600px] xl:max-w-[90%] md:w-full overflow-y-auto overflow-x-auto bg-white shadow-lg border-t-[1px] rounded-lg">
 			<div className="flex flex-wrap gap-4 text-sm font-medium text-gray-700 p-4">
 				<p>Total de produtos: {filteredProducts.length}</p>
 				<p>Preço total perdido: {formattedPrice(valueTrashProducts)}</p>


### PR DESCRIPTION
Melo, testing the app I've seen on mobile that 'TableProducts' it was not filling all the empty space, because of general max-width, so I took these changes to get responsiveness better.

Look before change: 
<img width="570" alt="Screenshot 2024-12-19 at 10 41 34" src="https://github.com/user-attachments/assets/0b659f97-87c9-425a-a1bd-06b703c3a76f" />
